### PR TITLE
fix(solo-play): fixed solo game, works as it should now

### DIFF
--- a/srcs/frontend/srcs/components/sidepanels/pongSidePanel.ts
+++ b/srcs/frontend/srcs/components/sidepanels/pongSidePanel.ts
@@ -25,7 +25,11 @@ export function createPongSidePanel() {
 	sidePanel.appendChild(createSidePanelButton({
 		title: i18nHandler.getValue("navbar.pong.submenu.solo"),
 		i18n: "navbar.pong.submenu.solo",
-		logo: buttonLogo
+		logo: buttonLogo,
+		f: () => {
+			RoutingHandler.setRoute("/pong");
+			startGame(`wss://${location.host}/api/game/computer`);
+		}
 	}));
 
 	sidePanel.appendChild(createSidePanelButton({

--- a/srcs/games/pong/srcs/plugins/game/classes/GameClass.ts
+++ b/srcs/games/pong/srcs/plugins/game/classes/GameClass.ts
@@ -48,7 +48,7 @@ export default class Game {
 	private _walls: WallMap;
 	private _room: GameRoom | null = null;
 
-	constructor() {
+	constructor(vsAI: boolean = false) {
 		this._field = new PlayField();
 		this._scene = this._field.getScene();
 
@@ -141,6 +141,12 @@ export default class Game {
 		this._p2.getMesh().refreshBoundingInfo(true);
 		this._ball.getHitbox().refreshBoundingInfo(true);
 
+		if (vsAI)
+			this._p2.setAI(true);
+			if (this._p2.getIsIA()) {
+				this._p2.setBall(this._ball);
+				this._p2.setWalls(this._walls);
+			}
 		// set ia brut
 		// this._p1.setAI(true);
 		// if (this._p1.getIsIA()) {

--- a/srcs/games/pong/srcs/plugins/game/classes/GameRoom.ts
+++ b/srcs/games/pong/srcs/plugins/game/classes/GameRoom.ts
@@ -62,10 +62,11 @@ export default class GameRoom {
 	public players: PlayerSession[] = [];
 	public game: Game;
 	public score: { p1: number; p2: number };
+	public lock: boolean = false;
 
-	constructor(id: string) {
+	constructor(id: string, vsAI: boolean = false) {
 		this.id = id;
-		this.game = new Game();
+		this.game = new Game(vsAI);
 		this.score = { p1: 0, p2: 0 };
 	}
 
@@ -92,8 +93,8 @@ export default class GameRoom {
 			playerSession.setPaddleId('p2');
 		}
 
-		if (this.isFull()) {
-			console.log(`Room ${this.id} full with players: [${this.players[0].getUserId()}, ${this.players[1].getUserId()}]`);
+		if (this.isFull() || this.lock) {
+			// console.log(`Room ${this.id} full with players: [${this.players[0].getUserId()}, ${this.players[1].getUserId()}]`);
 			console.log("GAME READY TO BE STARTED.");
 			this.startGame();
 		}


### PR DESCRIPTION
Changed logic for handling /computer route in backend
Added a hardlock for the room to NOT add more players to it
When user clicks `Play solo` he is the only WS connection to backend, the roomManager engages the lock and starts the game against AI.

Watch out for -> Game constructor can now take an optional boolean to turn on AI
              -> Game room constructor also has an optional boolean for AI