### PR TITLE
Fixes for issues 36 - 44

### DIFF
--- a/srcs/frontend/srcs/game/WebSocketManager.ts
+++ b/srcs/frontend/srcs/game/WebSocketManager.ts
@@ -67,7 +67,8 @@ export class WebSocketManager {
 			}
 			else if (msg.type === "update") {
 				this.onUpdate(msg.payload);
-				// TODO: Seperate score update with a different type
+			}
+			else if (msg.type === "score") {
 				PongGameManager.onScoreUpdate(msg.payload.score);
 			}
 		};

--- a/srcs/frontend/srcs/game/types.ts
+++ b/srcs/frontend/srcs/game/types.ts
@@ -26,12 +26,55 @@ export interface UpdatePayload {
 		ball: BallUpdate;
 		p1: PaddleUpdate;
 		p2: PaddleUpdate;
-		// Move score to another interface
-		score: {
-			p1: number;
-			p2: number;
-		};
 	}
+}
+
+export interface PlayerConnectedPayload {
+	type: "connect";
+	payload: {
+		playerID: string;
+		roomID: string;
+	}
+};
+
+export interface PlayerDisconnectedPayload {
+	type: "disconnect";
+	payload: {
+		playerID: string;
+	}
+};
+
+export interface CollisionPayload {
+	type: "collision";
+	payload: {
+		collider: string;
+	}
+};
+
+export interface ScoreUpdatePayload {
+	type: "score";
+	payload: {
+		score: {
+			p1: number,
+			p2: number
+		}
+	}
+}
+
+export interface GameOverPayload {
+	type: "gameover";
+	payload: {
+		winner: string;
+		final_score: {
+			p1: number,
+			p2: number
+		}
+	}
+}
+
+export interface ConnectedPlayers {
+	p1: string | undefined;
+	p2: string | undefined;
 }
 
 export interface BallInit extends BallUpdate {
@@ -59,7 +102,15 @@ export interface InitPayload {
 		walls: WallsInit;
 		camera: CameraInitInfo;
 		light: LightInitInfo;
+		roomID: string;
+		connectedPlayers: ConnectedPlayers;
 	}
 }
 
-export type ServerMessage = InitPayload | UpdatePayload;
+export type ServerMessage = InitPayload
+							| UpdatePayload
+							| PlayerConnectedPayload
+							| PlayerDisconnectedPayload
+							| CollisionPayload
+							| ScoreUpdatePayload
+							| GameOverPayload; 

--- a/srcs/games/pong/srcs/plugins/game/classes/Ball.ts
+++ b/srcs/games/pong/srcs/plugins/game/classes/Ball.ts
@@ -40,6 +40,8 @@ export default class Ball {
 	private _lastSpeedIncreaseBounce: number | undefined;
 	public direction: Vector3;
 
+	private _onCollision?: (collisionInfo: string) => void;
+
 	constructor(
 		scene: Scene,
 		name: string,
@@ -152,9 +154,16 @@ export default class Ball {
 			let boxA = this.getCollisionBox();
 			let boxB = collider.getCollisionBox();
 			if (BoundingBox.Intersects(boxA, boxB)) {
+				if (this._onCollision) {
+					this._onCollision(collider.getName());
+				}
 				collider.calculateBounce(this);
 				break;
 			}
 		}
+	}
+
+	public setOnCollision(callback: (collisionInfo: any) => void): void {
+		this._onCollision = callback;
 	}
 }

--- a/srcs/games/pong/srcs/plugins/game/classes/GameClass.ts
+++ b/srcs/games/pong/srcs/plugins/game/classes/GameClass.ts
@@ -224,6 +224,10 @@ export default class Game {
 		this._field.start(fps, this._broadcastUpdate || undefined);
 	}
 
+	public gameStop(): void {
+		this._field.stop();
+	}
+
 	public score(player: number): void {
 		if (this._room) {
 			this._room.addScore(player);

--- a/srcs/games/pong/srcs/plugins/game/classes/GameRoom.ts
+++ b/srcs/games/pong/srcs/plugins/game/classes/GameRoom.ts
@@ -60,7 +60,8 @@ interface InitPayload {
 interface PlayerConnectedPayload {
 	type: "connect",
 	payload: {
-		playerID: string
+		playerID: string,
+		roomID: string
 	}
 };
 
@@ -322,7 +323,8 @@ export default class GameRoom {
 		const playerConnectedPayload: PlayerConnectedPayload = {
 			type: "connect",
 			payload: {
-				playerID: sessions.getUserId()
+				playerID: sessions.getUserId(),
+				roomID: this.id
 			}
 		}
 		return playerConnectedPayload;

--- a/srcs/games/pong/srcs/plugins/game/classes/GameRoom.ts
+++ b/srcs/games/pong/srcs/plugins/game/classes/GameRoom.ts
@@ -5,57 +5,106 @@ import { type CameraInitInfo, type LightInitInfo } from "./Playfield.ts";
 import { DEFAULT_FPS } from "./Playfield.ts";
 
 interface BallUpdate {
-	curr_speed: number;
-	curr_position: number[];
-}
+	curr_speed: number,
+	curr_position: number[]
+};
 
 interface PaddleUpdate {
-	max_speed: number;
-	position: number[];
-}
+	max_speed: number,
+	position: number[]
+};
 
 interface RoomScore {
 	p1: number,
 	p2: number
-}
+};
 
-interface UpdatePayload {
-	type: "update";
-	payload: {
-		ball: BallUpdate;
-		p1: PaddleUpdate;
-		p2: PaddleUpdate;
-		score: RoomScore;
-	}
-}
 
 interface BallInit extends BallUpdate {
-	size: number[];
-}
+	size: number[],
+};
 
 interface PaddleInit extends PaddleUpdate { }
 
 interface WallsInit {
 	[key: string]: {
-		position: number[];
-		size: number[];
-		passThrough?: boolean;
-	};
-}
+		position: number[],
+		size: number[],
+		passThrough?: boolean
+	}
+};
+
+interface UpdatePayload {
+	type: "update",
+	payload: {
+		ball: BallUpdate,
+		p1: PaddleUpdate,
+		p2: PaddleUpdate
+	}
+};
 
 interface InitPayload {
-	type: "init";
+	type: "init",
 	payload: {
-		ball: BallInit;
-		p1: PaddleInit;
-		p2: PaddleInit;
-		walls: WallsInit;
-		camera: CameraInitInfo;
-		light: LightInitInfo;
+		ball: BallInit,
+		p1: PaddleInit,
+		p2: PaddleInit,
+		walls: WallsInit,
+		camera: CameraInitInfo,
+		light: LightInitInfo,
+		roomID: string,
+		connectedPlayers: ConnectedPlayers
+	}
+};
+
+interface PlayerConnectedPayload {
+	type: "connect",
+	payload: {
+		playerID: string
+	}
+};
+
+interface PlayerDisconnectedPayload {
+	type: "disconnect",
+	payload: {
+		playerID: string
+	}
+};
+
+interface CollisionPayload {
+	type: "collision",
+	payload: {
+		collider: string
+	}
+};
+
+interface ScoreUpdatePayload {
+	type: "score",
+	payload: {
+		score: RoomScore
 	}
 }
 
-type GameMessage = InitPayload | UpdatePayload;
+interface GameOverPayload {
+	type: "gameover",
+	payload: {
+		winner: string,
+		final_score: RoomScore
+	}
+}
+
+interface ConnectedPlayers {
+	p1: string | undefined,
+	p2: string | undefined
+}
+
+type GameMessage = InitPayload 
+				| UpdatePayload
+				| PlayerConnectedPayload
+				| PlayerDisconnectedPayload
+				| CollisionPayload
+				| ScoreUpdatePayload
+				| GameOverPayload;
 
 export default class GameRoom {
 
@@ -64,19 +113,28 @@ export default class GameRoom {
 	public game: Game;
 	public score: { p1: number; p2: number };
 	public lock: boolean = false;
+	private _lastMessage?: string;
+	private _lastCollision?: CollisionPayload;
 
-	constructor(id: string, vsAI: boolean = false) {
+	private _onGameOver?: (roomId: string) => void;
+
+	constructor(id: string, vsAI: boolean = false, onGameOver?: (roomId: string) => void) {
 		this.id = id;
 		this.game = new Game(vsAI);
 		const paddles: Paddle[] = this.game.getPaddles();
 		paddles.at(0)?.setGameRoom(this);
 		paddles.at(1)?.setGameRoom(this);
 		this.score = { p1: 0, p2: 0 };
+		this._onGameOver = onGameOver;
 	}
 
 	public isFull(): boolean {
 		console.log(`current players in room: ${this.players.length}`)
 		return this.players.length >= 2;
+	}
+
+	public isEmpty(): boolean {
+		return this.players.length === 0;
 	}
 
 	public getGame(): Game {
@@ -90,6 +148,7 @@ export default class GameRoom {
 	public addPlayer(playerSession: PlayerSession): void {
 		this.players.push(playerSession);
 		playerSession.setRoom(this);
+		this.broadcast(this.buildPlayerConnectedPayload(playerSession))
 
 		if (this.players.length === 1) {
 			playerSession.setPaddleId('p1');
@@ -104,22 +163,65 @@ export default class GameRoom {
 		}
 	}
 
+	public removePlayer(playerSession: PlayerSession): void {
+		this.players = this.players.filter(p => p !== playerSession);
+		console.log(`Removed player ${playerSession.getUserId()} from room ${this.id}`);
+
+		this.broadcast(this.buildPlayerDisconnectedPayload(playerSession));
+
+		if (this.isEmpty()) {
+			this.game.gameStop();
+			if (this._onGameOver) {
+				this._onGameOver(this.id);
+			}
+			return ;
+		}
+		playerSession.getPaddleId() === "p1" ? this.game.setP1IA(true) : this.game.setP2IA(true);
+		// on a player disconnect sets AI to missing player and locks the room
+		this.lock = true;
+	}
+
 	public addScore(player: number) {
 		player === 1 ? this.score.p1++ : this.score.p2++;
+		this.broadcast(this.buildScoreUpdatePayload());
+		if (this.score.p1 === 6) {
+			console.log("GAME OVER!, P1 Won!");
+			this._killGame(1);
+		} else if (this.score.p2 === 6) {
+			console.log("GAME OVER! P2 Won");
+			this._killGame(2);
+		}
 	}
 
 	public startGame() {
 
 		this.game.setBroadcastFunction(() => {
-			this.broadcast(this.buildUpdatePayload());
+			this.floodlessBroadcast(this.buildUpdatePayload());
 		});
 
 		this.game.setRoom(this);
+
+		const ball = this.game.getBall();
+		ball.setOnCollision((collisionInfo) => {
+			this.floodlessBroadcast(this.buildCollisionPayload(collisionInfo));
+		})
+
 		this.broadcast(this.buildInitPayload());
 		this.game.gameStart(DEFAULT_FPS);
 	}
 
+	private _killGame(winner: number) {
+		this.broadcast(this.buildGameOverPayload(winner));
+		this.game.gameStop();
+		if (this._onGameOver) {
+			this._onGameOver(this.id);
+		}
+	}
+
 	public broadcast(message: GameMessage): void {
+		if (message.type !== 'update') {
+			console.log(JSON.stringify(message, null, 2));
+		}
 		for (const p of this.players) {
 			try {
 				p.send(message)
@@ -129,6 +231,42 @@ export default class GameRoom {
 		}
 	}
 
+	public floodlessBroadcast(message: GameMessage): void {
+		
+		if (message.type === 'collision') {
+			const payload = message.payload;
+			if (
+				this._lastCollision &&
+				this._lastCollision.payload.collider === payload.collider
+			) {
+				return;
+			}
+			this._lastCollision = message;
+
+		} else if (message.type === 'update') {
+			const current = JSON.stringify(message);
+			if (this._lastMessage === current)
+				return;
+			this._lastMessage = current;
+		}
+
+		// debug
+		if (message.type !== 'update') {
+			console.log(JSON.stringify(message, null, 2));
+		}
+		// enddebug
+
+		for (const p of this.players) {
+			try {
+				p.send(message)
+			} catch (err) {
+				console.error(`Failed to send to player: ${this.id}: ${err}`);
+			}
+		}
+	}
+
+
+	/* BUILDING PAYLOADS ---------------------------------------------------------------------------- */
 	private buildInitPayload(): InitPayload {
 		const game = this.game;
 		const ball = game.getBall();
@@ -144,7 +282,12 @@ export default class GameRoom {
 				p2: p2.getInitInfo(),
 				walls: walls,
 				camera: lightsCamera.getCameraInitInfo(),
-				light: lightsCamera.getLightInitInfo()
+				light: lightsCamera.getLightInitInfo(),
+				roomID: this.id,
+				connectedPlayers: {
+					p1: this.players.at(0)?.getUserId(),
+					p2: this.players.at(1)?.getUserId()
+				}
 			}
 		}
 		return initPayload;
@@ -169,13 +312,63 @@ export default class GameRoom {
 				p2: {
 					max_speed: p2.getSpeed(),
 					position: p2.getPosition().asArray()
-				},
+				}
+			}
+		}
+		return updatePayload;
+	}
+
+	private buildPlayerConnectedPayload(sessions: PlayerSession): PlayerConnectedPayload {
+		const playerConnectedPayload: PlayerConnectedPayload = {
+			type: "connect",
+			payload: {
+				playerID: sessions.getUserId()
+			}
+		}
+		return playerConnectedPayload;
+	}
+
+	private buildPlayerDisconnectedPayload(sessions: PlayerSession): PlayerDisconnectedPayload {
+		const playerDisconnectedPayload: PlayerDisconnectedPayload = {
+			type: "disconnect",
+			payload: {
+				playerID: sessions.getUserId()
+			}
+		}
+		return playerDisconnectedPayload;
+	}
+
+	private buildScoreUpdatePayload(): ScoreUpdatePayload {
+		const scoreUpdate: ScoreUpdatePayload = {
+			type: "score",
+			payload: {
 				score: {
 					p1: this.score.p1,
 					p2: this.score.p2
 				}
 			}
 		}
-		return updatePayload;
+		return scoreUpdate;
+	}
+
+	private buildCollisionPayload(collisionInfo: string): CollisionPayload {
+		const collisionPayload: CollisionPayload = {
+			type: "collision",
+			payload: {
+				collider: collisionInfo
+			}
+		}
+		return collisionPayload;
+	}
+
+	private buildGameOverPayload(winner: number): GameOverPayload {
+		const gameOver: GameOverPayload = {
+			type: "gameover",
+			payload: {
+				winner: winner === 1 ? "p1" : "p2",
+				final_score: this.score
+			}
+		}
+		return gameOver;
 	}
 }

--- a/srcs/games/pong/srcs/plugins/game/classes/PlayerSession.ts
+++ b/srcs/games/pong/srcs/plugins/game/classes/PlayerSession.ts
@@ -9,12 +9,12 @@ export interface OutgoingMessage {
 
 export default class PlayerSession {
 	private _socket: WebSocket;
-	private _userId: string | null;
+	private _userId: string; // remove | null ;
 	private _playerReady: boolean;
 	private _room: GameRoom | null;
 	private _paddleId: string | null;
 
-	constructor(socket: WebSocket, userId: string | null = null) {
+	constructor(socket: WebSocket, userId: string) { // removed | null = null
 		this._socket = socket;
 		this._userId = userId;
 		this._playerReady = false;
@@ -23,7 +23,7 @@ export default class PlayerSession {
 	}
 
 	public getSocket(): WebSocket { return this._socket; }
-	public getUserId(): string | null { return this._userId; }
+	public getUserId(): string { return this._userId; } // removed | null
 	public isReady(): boolean { return this._playerReady; }
 	public getPaddleId(): string | null { return this._paddleId; }
 	public getRoom(): GameRoom | null { return this._room; }

--- a/srcs/games/pong/srcs/plugins/wsHandlers/baseWsHandler.ts
+++ b/srcs/games/pong/srcs/plugins/wsHandlers/baseWsHandler.ts
@@ -30,21 +30,31 @@ export function createWsHandler({ mode, manager }: CreateWsHandlerParams) {
 	return (socket: WebSocket, req: FastifyRequest<{ Querystring: GameWsQuery }>) => {
 		const query = req.query;
 
+		console.log(`User ID: ${query.userId}`);
+
 		if (!query.userId) {
 			socket.send(JSON.stringify({ type: '403', message: 'Unauthorized user' }));
 			socket.close();
 			return;
 		}
 
+		if (manager.getSession(query.userId)) {
+			socket.send(JSON.stringify({ type: 'ignored', message: 'Already in an active session'}));
+			socket.close();
+			return;
+		}
+
+
 		let session: PlayerSession;
 
+		
 		if (mode === 'friend_join') {
 			if (!query.roomId) {
 				socket.send(JSON.stringify({ type: '400', message: 'Missing roomId' }));
 				socket.close();
 				return;
 			}
-
+			
 			session = manager.assignPlayer(socket, {
 				userId: query.userId,
 				mode,
@@ -61,20 +71,18 @@ export function createWsHandler({ mode, manager }: CreateWsHandlerParams) {
 				mode: 'remote'
 			});
 		}
-
+		
 		console.log(`Player connected to room ${session.getRoom()?.id} as ${query.userId}`);
-
+		
 		socket.on('message', (msg) => {
 			try {
 				const { type, payload }: ClientMessage = JSON.parse(msg.toString());
 				if (type === 'ball' && payload?.direction && payload.direction == "launch") {
-					// console.log(`Launch command from ${session.getPaddleId()} | user: ${session.getUserId()}`);
 					let ball = session.getRoom()?.getGame().getBall();
 					ball?.launch();
-					ball?.setCurrSpeed(0.25);
+					ball?.setCurrSpeed(0.25); // ball.getBaseSpeed() instead of hardcode?
 				}
 				else if (type === 'move' && payload?.direction) {
-					// console.log(`Move command from ${session.getPaddleId()} | user: ${session.getUserId()}`);
 					const paddle = session.getPaddle();
 
 					if (paddle) {
@@ -95,6 +103,9 @@ export function createWsHandler({ mode, manager }: CreateWsHandlerParams) {
 							paddle.getIsIA() === true ? paddle.setAI(false) : paddle.setAI(true);
 					}
 				}
+				else if (type === 'disconnect') {
+					socket.close();
+				}
 			} catch (err) {
 				console.error('Invalid message from client:', err);
 			}
@@ -102,6 +113,7 @@ export function createWsHandler({ mode, manager }: CreateWsHandlerParams) {
 
 		socket.on('close', () => {
 			console.log(`User: ${query.userId} disconnected.`);
+			manager.removeSession(session);
 		})
 	};
 }


### PR DESCRIPTION
fixes #44 :
 - RoomID is now part of the InitPayload available on first player connection (PlayerConnectPayload)

fixes #42 :
 - Perform a check of userID before openning game session, soft rejecting a duplicate connection

fixes #41 :
 - User UID is sent with InitPayload (for all connected Users)

fixes #39 :
 - Collision message implemented (WARNING - ignore very first message on frontend, no solution yet)

fixes #37 :
 - Websocket should now close correctly on disconnect
 - Please add a message of type: "disconnect" from frontend when the user changes "screen" (i.e home)

fixes #36 
 - Payload for updates is checked statically before being sent as a duplicate