### PR TITLE
Update Docker and entrypoint configurations for TLS and port handling

### DIFF
--- a/srcs/core/docker-compose.yml
+++ b/srcs/core/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       - sarif-frontend:/var/www/sarif-frontend
     ports:
       - "443:443"
+      #- "80:80" can be enabled with USE_TLS=false
     build:
       context: .
     env_file:

--- a/srcs/core/docker-entrypoint.sh
+++ b/srcs/core/docker-entrypoint.sh
@@ -1,4 +1,22 @@
 #!/bin/sh
+
+if [ "$(echo "$USE_TLS" | tr '[:upper:]' '[:lower:]')" = "false" ]; then
+  echo "TLS is disabled."
+else
+  echo "TLS is enabled."
+fi
+
+if [ -z "$PORT" ]; then
+  echo "PORT environment variable is not set."
+  if [ "$(echo "$USE_TLS" | tr '[:upper:]' '[:lower:]')" = "false" ]; then
+    echo "Using PORT 80 (non-TLS mode)."
+    export PORT=80
+  else
+    echo "Using PORT 443 (TLS mode)."
+    export PORT=443
+  fi
+fi
+
 if [ -z "$CERT_PATH" ] || [ -z "$KEY_PATH" ]; then
   echo "CERT_PATH or KEY_PATH environment variable is not set."
   echo "Using default paths: /etc/ssl/certs/sarif.crt and /etc/ssl/private/sarif.key"

--- a/srcs/core/example.env
+++ b/srcs/core/example.env
@@ -2,6 +2,14 @@
 #CERT_PATH=
 #KEY_PATH=
 
+# If you want it to use HTTP instead of HTTPS (default: true)
+# This will only affect the core server -> the communication between the other modules will be on TLS.
+# USE_TLS = true
+
+# If you want to specify a port (default: if USE_TLS -> 443, else 80)
+# This will only affect the core server
+# PORT =
+
 # If ignoring TLS (default: false), set by main .env
 # IGNORE_TLS = true
 

--- a/srcs/core/srcs/core_main.ts
+++ b/srcs/core/srcs/core_main.ts
@@ -18,7 +18,7 @@ if (process.env.KEY_PATH === undefined || process.env.CERT_PATH === undefined) {
 }
 
 const fastify: fft.FastifyInstance = Fastify({
-	https: {
+	https: process.env.USE_TLS?.toLowerCase() === "false" ? false : {
 		key: fs.readFileSync(process.env.KEY_PATH),
 		cert: fs.readFileSync(process.env.CERT_PATH)
 	}
@@ -54,7 +54,7 @@ fastify.addHook('onSend', async (request, reply, payload) => {
 });
 
 
-fastify.listen({ port: 443, host: '::' }, (err) => {
+fastify.listen({ port: Number(process.env.PORT!), host: '::' }, (err) => {
 	if (err) {
 		fastify.log.error(err)
 		process.exit(1)

--- a/srcs/example.env
+++ b/srcs/example.env
@@ -5,6 +5,14 @@ RUNMODE=debug
 #CERT_PATH=
 #KEY_PATH=
 
+# If you want it to use HTTP instead of HTTPS (default: true)
+# This will only affect the core server -> the communication between the other modules will be on TLS.
+# USE_TLS = true
+
+# If you want to specify a port (default: if USE_TLS -> 443, else 80)
+# This will only affect the core server
+# PORT =
+
 # If ignoring TLS (default: false), set by main .env
 # IGNORE_TLS = true
 

--- a/srcs/frontend/srcs/game/WebSocketManager.ts
+++ b/srcs/frontend/srcs/game/WebSocketManager.ts
@@ -8,7 +8,7 @@ type InitHandler = (payload: InitPayload["payload"]) => void;
 type UpdateHanlder = (payload: UpdatePayload["payload"]) => void;
 type CollisionHandler = (payload: CollisionPayload["payload"]) => void;
 
-export const PONG_HOST = `wss://${location.host}/api/game/`
+export const PONG_HOST = `ws${location.protocol === "https:" ? "s" : ""}://${location.host}/api/game/`
 
 export class WebSocketManager {
 	private socket: WebSocket;


### PR DESCRIPTION
This pull request introduces changes to improve TLS (Transport Layer Security) configurability across the core server and frontend, allowing dynamic switching between HTTP and HTTPS based on environment variables. It also updates WebSocket handling in the frontend to adapt to the protocol used. Below are the most important changes grouped by theme:

### TLS Configurability in Core Server:
* [`srcs/core/docker-compose.yml`](diffhunk://#diff-60f4193e9fefd558c0d970c3f7cfc8def74ef9ebd32a43afe184eae81cf99565R25): Added a commented-out line for port 80 to indicate it can be enabled when `USE_TLS=false`.
* [`srcs/core/docker-entrypoint.sh`](diffhunk://#diff-dc40f9c4bb3168740cbfc4196b57a18fc052e573abfe5c3ea6b027d7dbd8af0aR2-R19): Added logic to dynamically set the `PORT` environment variable and display whether TLS is enabled or disabled based on `USE_TLS`. Defaults to port 443 for TLS and port 80 for non-TLS.
* [`srcs/core/srcs/core_main.ts`](diffhunk://#diff-7bde28e4561343f9c6c117e1080573369bae75c5c32a5b749c8adbc1577f421cL21-R21): Updated Fastify server initialization to disable HTTPS when `USE_TLS=false` and dynamically set the listening port from the `PORT` environment variable. [[1]](diffhunk://#diff-7bde28e4561343f9c6c117e1080573369bae75c5c32a5b749c8adbc1577f421cL21-R21) [[2]](diffhunk://#diff-7bde28e4561343f9c6c117e1080573369bae75c5c32a5b749c8adbc1577f421cL57-R57)

### Environment Variable Updates:
* `srcs/core/example.env` and `srcs/example.env`: Added comments and placeholders for `USE_TLS` and `PORT` environment variables to clarify their usage and default values. [[1]](diffhunk://#diff-4ea3e57b0c01987ff87996ec503ac3407402f7b146c653a1338cbe4ae8b4f156R5-R12) [[2]](diffhunk://#diff-d3361ea001ff26fcfb3b6344d988bc88616ee0282223b71029fc52d35a479ef1R8-R15)

### WebSocket Protocol Adaptation:
* [`srcs/frontend/srcs/game/WebSocketManager.ts`](diffhunk://#diff-109a211d61fd11dbb906820ae09b448a115ce7f637b4cbcb67077034125a4236L11-R11): Updated `PONG_HOST` to dynamically use `ws` or `wss` based on the current protocol (`http` or `https`).